### PR TITLE
feat:item_post update

### DIFF
--- a/trashion_back/item_post/serializers.py
+++ b/trashion_back/item_post/serializers.py
@@ -17,13 +17,13 @@ class UserSerializer(serializers.ModelSerializer):
 class PhotoSerializer(serializers.ModelSerializer):
     class Meta:
         model = Photo
-        fields = '__all__'
+        fields = ['item_id', 'photo']
 
 
 class StylePhotoSerializer(serializers.ModelSerializer):
     class Meta:
         model = StylePhoto
-        fields = '__all__'
+        fields = ['item_id', 'user_id', 'photo']
 
 
 class CategorySerializer(serializers.ModelSerializer):
@@ -49,6 +49,16 @@ class ItemSerializer(serializers.ModelSerializer):
         for style_photo_data in images_data.getlist('style_photos_data'):
             StylePhoto.objects.create(item_id=item, user_id=self.context['request'].user, photo=style_photo_data)
         return item
+
+    def update(self, instance, validated_data):
+        images_data = self.context['request'].FILES
+        Photo.objects.filter(item_id=instance).delete()
+        StylePhoto.objects.filter(item_id=instance).delete()
+        for photo_data in images_data.getlist('photos_data'):
+            Photo.objects.create(item_id=instance, photo=photo_data)
+        for style_photo_data in images_data.getlist('style_photos_data'):
+            StylePhoto.objects.create(item_id=instance, user_id=self.context['request'].user, photo=style_photo_data)
+        return instance
 
 
 class LocationSerializer(serializers.ModelSerializer):

--- a/trashion_back/item_post/views.py
+++ b/trashion_back/item_post/views.py
@@ -54,6 +54,11 @@ class ItemViewSet(ModelViewSet):
     def perform_create(self, serializer):
         serializer.save(user_id=self.request.user)
 
+    # update
+    # photo, stylephoto > serializers.py의 update()에서 처리
+    def perform_update(self, serializer):
+        serializer.save(user_id=self.request.user)
+
     # 내가 판매중인 아이템 조회
     @action(detail=False, methods=['GET'])
     def my_item(self, request):
@@ -88,6 +93,23 @@ class ItemViewSet(ModelViewSet):
         for i in locationsets:
             item_ids.append(i.item_id)
         serializer = self.get_serializer(item_ids, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    # 일반 이미지만 모아보기 : 같은 아이템에 사진 여러장일 경우에는 한장만!
+    # Q... 일반이미지가 있는 아이템을 넘겨줘야할지, 사진만 넘겨줘야할지...
+    @action(detail=False, methods=['GET'])
+    def photo_item_only(self, request):
+        item_ids = Photo.objects.distinct().values_list('item_id', flat=True)
+        items = Item.objects.filter(id__in=item_ids)
+        serializer = self.get_serializer(items, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    # 착장 이미지만 모아보기 : 같은 아이템에 사진 여러장일 경우에는 한장만!
+    @action(detail=False, methods=['GET'])
+    def stylephoto_item_only(self, request):
+        item_ids = StylePhoto.objects.distinct().values_list('item_id', flat=True)
+        items = Item.objects.filter(id__in=item_ids)
+        serializer = self.get_serializer(items, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 


### PR DESCRIPTION
**item_post의 update기능 구현**

- serializers.py에서 이미지필드 업데이트구현

**item_post의 read기능 몇가지 구현**

- my_item : 내가 판매중인 아이템 모아보기
- category_item : 카테고리별로 아이템 모아보기
- location_item : 지역별로 아이템 모아보기 (시는 단일선택, 구/동은 다중선택)
- photo_item_only : 일반 이미지만 모아보기
- stylephoto_item_only : 착장 이미지만 모아보기 